### PR TITLE
Add possibility to specify git remote name

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -3,13 +3,17 @@
 var proc = require('child_process')
 var path = require('path')
 var edit = require('string-editor')
+var minimist = require('minimist')
+
+var argv = minimist(process.argv.slice(2))
+var remote = argv.remote || 'deploy'
 
 var onerror = function (err) {
   console.error(err.message || err)
   process.exit(1)
 }
 
-if (!process.argv[2]) onerror('Usage: taco-git-push-deploy user@remote-server.com')
+if (!argv._[0]) onerror('Usage: taco-git-push-deploy user@remote-server.com')
 
 try {
   var name = require(path.resolve('./package.json')).name
@@ -35,14 +39,14 @@ proc.exec('git status', function (err) {
       + 'mkdir -p ' + repo + ' && cd ' + repo + '; ([ ! -d hooks ] && git init --bare);'
       + 'printf ' + JSON.stringify(str) + ' > hooks/post-receive; chmod +x hooks/post-receive'
 
-    var child = proc.spawn('ssh', [process.argv[2], cmd], {
+    var child = proc.spawn('ssh', [argv._[0], cmd], {
       stdio: 'inherit'
     })
 
     child.on('exit', function (code) {
       if (code) return process.exit(code)
-      proc.exec('git remote rm deploy; git remote add deploy ' + process.argv[2] + ':' + repo, function () {
-        console.log('Taco pipeline created. To deploy simply do:\n\n  git push deploy master\n')
+      proc.exec('git remote rm ' + remote + '; git remote add ' + remote + ' ' + argv._[0] + ':' + repo, function () {
+        console.log('Taco pipeline created. To deploy simply do:\n\n  git push ' + remote + ' master\n')
       })
     })
   })

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "git push deploy with taco",
   "main": "index.js",
   "dependencies": {
+    "minimist": "^1.2.0",
     "string-editor": "^0.1.1"
   },
   "devDependencies": {},


### PR DESCRIPTION
Make it possible to specify remote name as a command-line option.

```
taco-git-push-deploy user@server --remote deploy-staging
```
